### PR TITLE
feat: 팀 목록 상세/지원 페이지 완료(제출 버튼 확인창 제외)

### DIFF
--- a/teamkerbell_frontend/src/App.js
+++ b/teamkerbell_frontend/src/App.js
@@ -16,6 +16,8 @@ import CompMatching from "./pages/comp";
 import CompReviews from "./pages/reviews";
 import Mypage from "./pages/mypage";
 import TeamDetail from "./pages/teamdetail";
+import TeamApply from "./pages/teamapply";
+import EditProfile from "./components/myPageComponents/EditProfile";
 
 
 function App() {
@@ -27,6 +29,9 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/mypage" element={<Mypage />} />
+        {/* 이력서 수정 페이지로 수정 필요 */}
+        <Route path="/mypage/user/:userId/resume/:resumeId" element={<Mypage/>}/> 
+
         <Route path="/team/tid" element={<Team />} />
         <Route
           path="/team/tid/guideline1"
@@ -46,6 +51,7 @@ function App() {
         <Route path="/comp/:compId" element={<CompMatching />} />
         <Route path="/comp/:compId/reviews" element={<CompReviews />} />
         <Route path="/comp/:compId/teamList/:teamId/detail" element = {<TeamDetail/>} />
+        <Route path="/comp/:compId/teamList/:teamId/apply" element = {<TeamApply/>}/>
         
       </Routes>
     </BrowserRouter>

--- a/teamkerbell_frontend/src/components/matchingComponents/ApplyResume.jsx
+++ b/teamkerbell_frontend/src/components/matchingComponents/ApplyResume.jsx
@@ -1,0 +1,91 @@
+import ComplimentManTag from "../../stores/tags/ComplimentManTag";
+import FireManTag from "../../stores/tags/FireManTag";
+import GoodListenerManTag from "../../stores/tags/GoodListenerManTag";
+import PlannerManTag from "../../stores/tags/PlannerManTag";
+import styles from "./ApplyResume.module.css";
+import SingleAndDoubleClick from "./SingleAndDoubleClick";
+import React from 'react';
+import { useNavigate, useParams } from "react-router-dom";
+
+
+const tagComponents = {
+  0: ComplimentManTag,
+  1: FireManTag,
+  2: GoodListenerManTag,
+  3: PlannerManTag,
+  // 이런 식으로 필요한 만큼 추가할 수 있습니다.
+};
+
+const ApplyResume = ({ user, resume, isSelected, onSelect }) => {
+
+
+    const { userId } = useParams();
+
+
+    const navigate = useNavigate();
+
+    // 한번 클릭 시, 이력서 선택
+    const handleClick = () => {
+        onSelect(resume.id);
+        console.log("선택된 이력서 번호: "+resume.id);
+
+    };
+
+    // 두번 클릭 시, 이력서 수정
+    const handleDoubleClick = () => {
+        console.log("이력서 수정");
+        navigate(`/mypage/user/${user}/resume/${resume.id}`);
+        
+    }
+
+    const resumeItem = isSelected ? styles.selectedResume : styles.resumeItem; //이력서 선택 시 스타일 변경
+
+    const click = SingleAndDoubleClick(handleClick, handleDoubleClick); //클릭 횟수 처리
+
+  return (
+    <div className={resumeItem} onClick={click}>
+      <div className={styles.profileImgNName}>
+        <img src="/dummy_profile.png" alt="유저 이미지" />
+        <div className={styles.nameNTemp}>
+          <h1>{resume.name}</h1>
+          <p>온도 : {resume.temperature}</p>
+        </div>
+      </div>
+      <p className={styles.resumeContent}>{resume.content}</p>
+      <h3 className={styles.greenColor}>Details:</h3>
+      <ul>
+        <li>
+          <span className={styles.label}>이름:</span> <span>{resume.name}</span>
+        </li>
+        <li>
+          <span className={styles.label}>나이:</span> <span>{resume.age}</span>
+        </li>
+        <li>
+          <span className={styles.label}>설명:</span>{" "}
+          <span>{resume.occupation}</span>
+        </li>
+        <li>
+          <span className={styles.label}>기술:</span>{" "}
+          <span>{resume.skills}</span>
+        </li>
+        <li>
+          <span className={styles.label}>백준 티어:</span>{" "}
+          <span>{resume.baekjoonTier}</span>
+        </li>
+        <li>
+          <span className={styles.label}>Github:</span>{" "}
+          <span>{resume.github}</span>
+        </li>
+      </ul>
+      <div className={styles.tagContainer}>
+        {resume.tags.length > 0 &&
+          resume.tags.map((tag, index) => {
+            const TagComponent = tagComponents[tag];
+            return <TagComponent key={index} />;
+          })}
+      </div>
+    </div>
+  );
+};
+
+export default ApplyResume;

--- a/teamkerbell_frontend/src/components/matchingComponents/ApplyResume.module.css
+++ b/teamkerbell_frontend/src/components/matchingComponents/ApplyResume.module.css
@@ -1,0 +1,84 @@
+@font-face {
+    font-family: "NanumSquareRound";
+    src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_two@1.0/NanumSquareRound.woff")
+      format("woff");
+    /*웹폰트 사용*/
+    font-weight: normal;
+    font-style: normal;
+  }
+  .resumeItem {
+    width: calc(
+      50% - 20px
+    ); /* 2xN 그리드 형식으로 표현하기 위해 50%의 너비 지정 */
+    margin: 10px;
+    padding: 20px 40px;
+    border: 1px solid #66a97c; /* 테두리 스타일 및 색상 지정 */
+    border-radius: 15px;
+    box-sizing: border-box; /* 패딩과 테두리를 포함한 전체 너비로 계산 */
+  }
+  
+  .profileImgNName {
+    display: flex;
+  }
+  .profileImgNName img {
+    width: 100px;
+    height: 100px;
+    margin-top: 20px;
+    border-radius: 50px;
+  }
+  .nameNTemp {
+    margin-left: 50px;
+  }
+  .nameNTemp p {
+    font-size: 20px;
+    color: rgb(111, 111, 111);
+  }
+  .greenColor {
+    font-size: 30px;
+    color: #66a97c;
+  }
+  .label {
+    flex: 0 0 120px; /* 레이블의 너비를 고정으로 지정 */
+  }
+  .resumeItem h2 {
+    margin-top: 0;
+  }
+  
+  .resumeItem ul {
+    list-style: none;
+    padding: 0;
+  }
+  
+  .resumeItem ul li {
+    margin-bottom: 5px;
+  }
+  
+  .tagContainer {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .selectedResume {
+    background-color: #f0f0f0; /* 선택됐을 때의 배경색 */
+    width: calc(
+      50% - 20px
+    ); /* 2xN 그리드 형식으로 표현하기 위해 50%의 너비 지정 */
+    margin: 10px;
+    padding: 20px 40px;
+    border: 1px solid #66a97c; /* 테두리 스타일 및 색상 지정 */
+    border-radius: 15px;
+    box-sizing: border-box; /* 패딩과 테두리를 포함한 전체 너비로 계산 */
+}
+
+.selectedResume h2 {
+    margin-top: 0;
+  }
+  
+.selectedResume ul {
+    list-style: none;
+    padding: 0;
+}
+  
+.selectedResume ul li {
+    margin-bottom: 5px;
+}

--- a/teamkerbell_frontend/src/components/matchingComponents/SingleAndDoubleClick.jsx
+++ b/teamkerbell_frontend/src/components/matchingComponents/SingleAndDoubleClick.jsx
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+function SingleAndDoubleClick(actionSimpleClick, actionDoubleClick, delay = 250) {
+    const [click, setClick] = useState(0);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            // simple click
+            if (click === 1) actionSimpleClick();
+            setClick(0);
+        }, delay);
+
+        // the duration between this click and the previous one
+        // is less than the value of delay = double-click
+        if (click === 2) actionDoubleClick();
+
+        return () => clearTimeout(timer);
+        
+    }, [click]);
+
+    return () => setClick(prev => prev + 1);
+}
+
+export default SingleAndDoubleClick;

--- a/teamkerbell_frontend/src/components/matchingComponents/TeamOutline.module.css
+++ b/teamkerbell_frontend/src/components/matchingComponents/TeamOutline.module.css
@@ -6,7 +6,7 @@
 
 .teamoutlinecontainer {
     font-family: 'Arial', sans-serif; 
-    padding: 50px; 
+    padding: 100px; 
     margin: 0px 50px; 
 }
 

--- a/teamkerbell_frontend/src/pages/teamapply.jsx
+++ b/teamkerbell_frontend/src/pages/teamapply.jsx
@@ -1,0 +1,180 @@
+import React from "react";
+import styles from "./teamapply.module.css";
+import TeamOutline from "../components/matchingComponents/TeamOutline";
+import Portfolios from "../components/myPageComponents/Potfolios";
+import ApplyResume from "../components/matchingComponents/ApplyResume"; 
+import SingleAndDoubleClick from "../components/matchingComponents/SingleAndDoubleClick";
+import { Link ,useState } from 'react';
+
+
+
+const TeamApply = ( ) => {
+
+    //유저 ID
+    const DUMMY_USER_ID = 3;
+
+    const DUMMY_TEAM_OUTLINE = {
+        title: "교보생명 대학생 디자인 공모전 팀원 구합니다!",
+        profileimg: "/Male User.png",
+        writer: "Danny",
+        uploaddate: "2024.04.07",
+        category: "공모전",
+        meetingway: "온/오프라인",
+        recruitnum: 4,
+        startdate: "2024.04.21",
+        recruitjobs: ["디자이너", "백엔드", "프론트엔드", "기획"],
+        languages: ["HTML", "CSS", "Django"],
+        location: "서울",
+      };
+
+    const DUMMY_TEAM_MEMBER={
+        design: 1,
+        frontend: 2,
+        backend: 2,
+        pm: 0
+    };
+
+
+    const DUMMY_RESUMES = [
+      {
+        id:0,
+        temperature: 42.5,
+        title: "규진's 이력서",
+        content:
+          "안녕하세요, 저는 풀스택 개발자 김동국입니다. 작년에 AI 생성 공모전을 참가하여 경험을 쌓았으며 이를 바탕으로 이번에는 수상을 해보고 싶습니다. 그만큼, 최선을 다하고 열심히 하겠습니다. 감사합니다. 뽑아주세요!",
+        name: "홍규진",
+        age: 24,
+        occupation: "프론트엔드 개발/백엔드 개발",
+        skills: "JavaScript, React, Django, Flutter",
+        baekjoonTier: "Gold",
+        github: "github.com/kyujenius",
+        tags: [0, 1, 2, 3],
+      },
+
+      {
+        id:1,
+        temperature: 42.5,
+        title: "규진's 이력서",
+        content:
+          "안녕하세요, 저는 풀스택 개발자 김동국입니다. 작년에 AI 생성 공모전을 참가하여 경험을 쌓았으며 이를 바탕으로 이번에는 수상을 해보고 싶습니다. 그만큼, 최선을 다하고 열심히 하겠습니다. 감사합니다. 뽑아주세요!",
+        name: "홍규진",
+        age: 24,
+        occupation: "프론트엔드 개발/백엔드 개발",
+        skills: "JavaScript, React, Django, Flutter",
+        baekjoonTier: "Gold",
+        github: "github.com/kyujenius",
+        tags: [0, 1, 2, 3],
+      },
+
+      {
+        id:2,
+        temperature: 42.5,
+        title: "규진's 이력서",
+        content:
+          "안녕하세요, 저는 풀스택 개발자 김동국입니다. 작년에 AI 생성 공모전을 참가하여 경험을 쌓았으며 이를 바탕으로 이번에는 수상을 해보고 싶습니다. 그만큼, 최선을 다하고 열심히 하겠습니다. 감사합니다. 뽑아주세요!",
+        name: "홍규진",
+        age: 24,
+        occupation: "프론트엔드 개발/백엔드 개발",
+        skills: "JavaScript, React, Django, Flutter",
+        baekjoonTier: "Gold",
+        github: "github.com/kyujenius",
+        tags: [0, 1, 2, 3],
+      },
+      
+      {
+        id:3,
+        temperature: 42.5,
+        title: "규진's 이력서",
+        content:
+          "안녕하세요, 저는 풀스택 개발자 김동국입니다. 작년에 AI 생성 공모전을 참가하여 경험을 쌓았으며 이를 바탕으로 이번에는 수상을 해보고 싶습니다. 그만큼, 최선을 다하고 열심히 하겠습니다. 감사합니다. 뽑아주세요!",
+        name: "홍규진",
+        age: 24,
+        occupation: "프론트엔드 개발/백엔드 개발",
+        skills: "JavaScript, React, Django, Flutter",
+        baekjoonTier: "Gold",
+        github: "github.com/kyujenius",
+        tags: [0, 1, 2, 3],
+      },
+    ];
+
+
+    //지원 분야 상태 관리
+    const [selectedRole, setSelectedRole] = useState("");
+
+    const handleSelectRole = (e) => {
+      setSelectedRole(e.target.value);
+      console.log("선택된 지원 분야: "+e.target.value);
+    }
+
+
+    //이력서 상태 관리
+    const [selectedResumeId, setSelectedResumeId] = useState(null);
+
+    const handleSelectResume = (id) => {
+        setSelectedResumeId(id);
+    };
+
+
+
+    return(
+        <div className={styles.container}>
+            {/* 팀 개요 */}
+            <div className={styles.teamoutline}>
+              <TeamOutline
+                title={DUMMY_TEAM_OUTLINE.title}
+                profileimg={DUMMY_TEAM_OUTLINE.profileimg}
+                writer={DUMMY_TEAM_OUTLINE.writer}
+                uploaddate={DUMMY_TEAM_OUTLINE.uploaddate}
+                category={DUMMY_TEAM_OUTLINE.category}
+                meetingway={DUMMY_TEAM_OUTLINE.meetingway}
+                recruitnum={DUMMY_TEAM_OUTLINE.recruitnum}
+                startdate={DUMMY_TEAM_OUTLINE.startdate}
+                recruitjobs={DUMMY_TEAM_OUTLINE.recruitjobs}
+                languages={DUMMY_TEAM_OUTLINE.languages}
+                location={DUMMY_TEAM_OUTLINE.location}
+              />
+            </div>
+            
+            <hr className={styles.line}></hr>
+
+            {/* 지원 */}
+            <div className={styles.apply}>
+              <div className={styles.applyfield}>
+                <div className={styles.applyfieldtext}>지원 분야</div>
+                <select className={styles.selectapplyfield} onChange={handleSelectRole} value={selectedRole}>
+                  <option value="" disabled selected>분야 선택</option>
+                  <option value="design" disabled={DUMMY_TEAM_MEMBER.design === 0}>디자인 {DUMMY_TEAM_MEMBER.design}명</option>
+                  <option value="frontend" disabled={DUMMY_TEAM_MEMBER.frontend === 0}>프론트엔드 {DUMMY_TEAM_MEMBER.frontend}명</option>
+                  <option value="backend" disabled={DUMMY_TEAM_MEMBER.backend === 0}>백엔드 {DUMMY_TEAM_MEMBER.backend}명</option>
+                  <option value="pm" disabled={DUMMY_TEAM_MEMBER.pm === 0}>기획 {DUMMY_TEAM_MEMBER.pm}명</option>
+                </select>
+              </div>
+
+              {/* 이력서 선택 */}
+              <div className={styles.selectresumefield}>
+                <div className={styles.selectresume}>이력서 선택</div>
+                <div className={styles.resumeContainer}>
+
+                  {DUMMY_RESUMES.map((resume) => (
+                    <ApplyResume className={styles.resumeItem} 
+                      key={resume.id}  
+                      user={DUMMY_USER_ID}
+                      resume={resume} 
+                      isSelected={selectedResumeId === resume.id} 
+                      onSelect={handleSelectResume}/>
+                  ))}
+                </div>
+              </div>
+
+              <div className={styles.submit}>
+                <div className={styles.submitbtn}>제출</div>
+              </div>
+              
+            </div>
+
+            
+
+        </div>
+    );
+}
+export default TeamApply;

--- a/teamkerbell_frontend/src/pages/teamapply.module.css
+++ b/teamkerbell_frontend/src/pages/teamapply.module.css
@@ -1,0 +1,86 @@
+
+
+.container{
+    padding: 50px; 
+    margin: 0px 50px; 
+}
+
+
+.line{
+   margin:0px 150px;
+}
+
+.apply{
+    margin:30px 150px;
+}
+
+.applyfield{
+    margin:30px 0px;
+    text-align: right;
+}
+
+.applyfieldtext{
+    font-weight:bold;
+    font-size:1.8rem;
+    text-align:left;
+}
+
+.selectapplyfield{
+    margin-top: 20px;
+    
+}
+
+select{
+    height: 50px;
+    width: 300px;
+    padding-left: 10px;
+}
+
+select option[value=""][disabled] {
+	display: none;
+}
+
+.selectresumefield{
+    margin-top: 20px;
+
+}
+
+.selectresume{
+    font-weight:bold;
+    font-size:1.8rem;
+    margin: 20px 0px;
+}
+
+.resumeContainer {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between; /* 컨테이너 내에서 아이템 간 간격을 균등하게 설정 */
+}
+
+.resumeItem {
+    width: 40%; 
+    margin-bottom: 30px;
+}
+
+
+.submit{
+    display: flex;
+    justify-content: center;
+
+}
+
+.submitbtn{
+    color: white;
+    text-decoration: none;
+    font-family: "NanumSquareRoundB";
+    font-size: 1.5rem;
+    text-align: center;
+    border: 1px solid #026423;
+    opacity: 0.8;
+    border-radius: 10px;
+    width: 40%;
+    padding: 15px;
+    background-color: #026423;
+    margin:20px;
+
+}

--- a/teamkerbell_frontend/src/pages/teamdetail.jsx
+++ b/teamkerbell_frontend/src/pages/teamdetail.jsx
@@ -9,7 +9,7 @@ const TeamDetail = () => {
 
   const DUMMY_TEAM_OUTLINE = {
     title: "교보생명 대학생 디자인 공모전 팀원 구합니다!",
-    profileimg: "/leadercrown.png",
+    profileimg: "/Male User.png",
     writer: "Danny",
     uploaddate: "2024.04.07",
     category: "공모전",


### PR DESCRIPTION
- 지원 분야 선택 시, 모집 인원이 0명일 때 해당 분야 선택 불가
- 이력서 한번 클릭 시, 하나의 이력서만 가능/배경 색 변화
- 이력서 더블 클릭 시, 이력서 수정 페이지 /mypage/user/${user}/resume/${resume.id}로 이동 (userId Dummy로 작업)
- 지원 분야 및 이력서 선택 시 데이터 값 console에 출력 확인 완료
- 제출 버튼 클릭 시 확인 창 미완료