### PR TITLE
fix: 신청취소 api에서 여러 TeamMate 튜플을 참조하는 문제 해결

### DIFF
--- a/teamkerbell_backend/teamkerbell/user/views.py
+++ b/teamkerbell_backend/teamkerbell/user/views.py
@@ -313,7 +313,7 @@ def cancelJoin(request, user_id, team_id):
     except BasicUser.DoesNotExist:
         return Response({'error' : {'code' : 404, 'message' : "User not found!"}}, status=status.HTTP_404_NOT_FOUND)
     try:
-            teammate=TeamMate.objects.get(user=user, isTeam=False)
+            teammate=TeamMate.objects.get(team=team, user=user, isTeam=False)
     except TeamMate.DoesNotExist:
         return Response({'error': {'code': 404, 'message': "TeamMate not found!"}}, status=status.HTTP_404_NOT_FOUND) 
     if request.method == 'DELETE':


### PR DESCRIPTION
신청취소 api에서 여러 TeamMate 튜플을 참조하는 문제 해결