### PR TITLE
feat: 상호평가 종료여부를 확인하는 FinalCheck테이블 추가, 그에 따른 상호평가 로직 수정

### DIFF
--- a/teamkerbell_backend/teamkerbell/team/models.py
+++ b/teamkerbell_backend/teamkerbell/team/models.py
@@ -69,3 +69,9 @@ class PreviousWinning(models.Model):
     comp = models.ForeignKey('comp.Comp', related_name= 'previouswinnings', on_delete=models.SET_NULL, null=True)
     title= models.CharField(null=False, max_length=100, default="default_value")
     interview = models.TextField(null=False)
+
+class FinalCheck(models.Model):
+    id = models.AutoField(primary_key=True, null=False)
+    user = models.ForeignKey('user.BasicUser',related_name="finalChecks",on_delete=models.SET_NULL, null=True)
+    reporter = models.ForeignKey('user.BasicUser',related_name="finalChecksReporters",on_delete=models.SET_NULL, null=True)
+    team = models.ForeignKey(Team, related_name="finalChecks", on_delete=models.CASCADE, null=False)

--- a/teamkerbell_backend/teamkerbell/user/views.py
+++ b/teamkerbell_backend/teamkerbell/user/views.py
@@ -390,7 +390,7 @@ def resumeAccept(request, user_id, team_id, resume_id):
             try:
                 teamrole = TeamRole.objects.get(team=team, role=teammate.role)  
             except TeamRole.DoesNotExist:
-                return Response({'error' : {'code' : 404, 'message' : "TeamMate not found!"}}, status=status.HTTP_404_NOT_FOUND)
+                return Response({'error' : {'code' : 404, 'message' : "TeamRole not found!"}}, status=status.HTTP_404_NOT_FOUND)
 
             
             accept = serializer.validated_data['accept']


### PR DESCRIPTION
상호평가 종료여부를 확인하는 FinalCheck테이블 추가
상호평가 로직에서 FinalCheck테이블을 통해 상호평가를 완료한 인원인지 확인하고
상호평가가 종료되면 팀 관련 테이블들을 모두 삭제